### PR TITLE
Android用に、キーボート表示隠す Eventの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keyboard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cordova Keyboard Plugin",
   "cordova": {
     "id": "cordova-plugin-keyboard",

--- a/src/android/Keyboard.java
+++ b/src/android/Keyboard.java
@@ -8,10 +8,23 @@ import org.apache.cordova.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.apache.cordova.PluginResult.Status;
+import android.graphics.Rect;
+import android.util.DisplayMetrics;
+import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+
+/**
+ * dejiren https://github.com/cjpearson/cordova-plugin-keyboard/pull/15 修正の取り込み
+ */
 public class Keyboard extends CordovaPlugin {
 
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+    public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
 	Activity activity = this.cordova.getActivity();
 	InputMethodManager imm = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
 
@@ -32,7 +45,57 @@ public class Keyboard extends CordovaPlugin {
 	    imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
 	    callbackContext.success();
 	    return true;
-	}
+	} else if ("init".equals(action)) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+            	//calculate density-independent pixels (dp)
+                //http://developer.android.com/guide/practices/screens_support.html
+                DisplayMetrics dm = new DisplayMetrics();
+				cordova.getActivity().getWindowManager().getDefaultDisplay().getMetrics(dm);
+                final float density = dm.density;
+
+                //http://stackoverflow.com/a/4737265/1091751 detect if keyboard is showing
+				// 全画面表示の際、getDecorView()まででOKです。
+                final View rootView = cordova.getActivity().getWindow().getDecorView().findViewById(android.R.id.content).getRootView();
+                final int MIN_KEYBOARD_HEIGHT_PX = 100;
+				OnGlobalLayoutListener list = new OnGlobalLayoutListener() {
+                    int previousHeightDiff = 0;
+                    @Override
+                    public void onGlobalLayout() {
+                        Rect r = new Rect();
+                        //r will be populated with the coordinates of your view that area still visible.
+                        rootView.getWindowVisibleDisplayFrame(r);
+
+                        PluginResult result;
+
+                        int heightDiff = rootView.getRootView().getHeight() - r.bottom;
+                        int pixelHeightDiff = (int)(heightDiff / density);
+                        if (pixelHeightDiff > MIN_KEYBOARD_HEIGHT_PX && pixelHeightDiff != previousHeightDiff) { // if more than 100 pixels, its probably a keyboard...
+                        	String msg = "S" + Integer.toString(pixelHeightDiff);
+                            result = new PluginResult(PluginResult.Status.OK, msg);
+                            result.setKeepCallback(true);
+                            callbackContext.sendPluginResult(result);
+                        }
+                        else if ( pixelHeightDiff != previousHeightDiff && ( previousHeightDiff - pixelHeightDiff ) > 100 ){
+                        	String msg = "H";
+                            result = new PluginResult(PluginResult.Status.OK, msg);
+                            result.setKeepCallback(true);
+                            callbackContext.sendPluginResult(result);
+                        }
+                        previousHeightDiff = pixelHeightDiff;
+                     }
+                };
+
+                rootView.getViewTreeObserver().addOnGlobalLayoutListener(list);
+
+
+                PluginResult dataResult = new PluginResult(PluginResult.Status.OK);
+                dataResult.setKeepCallback(true);
+                callbackContext.sendPluginResult(dataResult);
+            }
+        });
+        return true;
+    }
 	callbackContext.error(action + " is not a supported action");
 	return false;
     }

--- a/www/keyboard.js
+++ b/www/keyboard.js
@@ -17,90 +17,108 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
-var argscheck = require('cordova/argscheck'),
-    utils = require('cordova/utils'),
-    exec = require('cordova/exec');
-   
-var Keyboard = function() {
+var argscheck = require("cordova/argscheck"),
+  utils = require("cordova/utils"),
+  exec = require("cordova/exec");
+channel = require("cordova/channel");
+
+var Keyboard = function () {};
+
+Keyboard.shrinkView = function (shrink, success) {
+  if (shrink !== null && shrink !== undefined) {
+    exec(success, null, "Keyboard", "shrinkView", [shrink]);
+  } else {
+    exec(success, null, "Keyboard", "shrinkView", []);
+  }
 };
 
-Keyboard.shrinkView = function(shrink, success) {
-    if (shrink !== null && shrink !== undefined) {
-        exec(success, null, "Keyboard", "shrinkView", [shrink]);
-    } else {
-        exec(success, null, "Keyboard", "shrinkView", []);
-    }
+Keyboard.hideFormAccessoryBar = function (hide, success) {
+  if (hide !== null && hide !== undefined) {
+    exec(success, null, "Keyboard", "hideFormAccessoryBar", [hide]);
+  } else {
+    exec(success, null, "Keyboard", "hideFormAccessoryBar", []);
+  }
 };
 
-Keyboard.hideFormAccessoryBar = function(hide, success) {
-    if (hide !== null && hide !== undefined){
-        exec(success, null, "Keyboard", "hideFormAccessoryBar", [hide]);
-    } else {
-        exec(success, null, "Keyboard", "hideFormAccessoryBar", []);
-    }
+Keyboard.disableScrollingInShrinkView = function (disable, success) {
+  if (disable !== null && disable !== undefined) {
+    exec(success, null, "Keyboard", "disableScrollingInShrinkView", [disable]);
+  } else {
+    exec(success, null, "Keyboard", "disableScrollingInShrinkView", []);
+  }
 };
 
-Keyboard.disableScrollingInShrinkView = function(disable, success) {
-    if (disable !== null && disable !== undefined) {
-        exec(success, null, "Keyboard", "disableScrollingInShrinkView", [disable]);
-    } else {
-        exec(success, null, "Keyboard", "disableScrollingInShrinkView", []);
-    }
+Keyboard.fireOnShow = function () {
+  Keyboard.isVisible = true;
+  cordova.fireWindowEvent("keyboardDidShow");
+
+  if (Keyboard.onshow) {
+    Keyboard.onshow();
+  }
 };
 
-Keyboard.fireOnShow = function() {
-    Keyboard.isVisible = true;
-    cordova.fireWindowEvent('keyboardDidShow');
+Keyboard.fireOnHide = function () {
+  Keyboard.isVisible = false;
+  cordova.fireWindowEvent("keyboardDidHide");
 
-    if(Keyboard.onshow) {
-	Keyboard.onshow();
-    }
+  if (Keyboard.onhide) {
+    Keyboard.onhide();
+  }
 };
 
-Keyboard.fireOnHide = function() {
-    Keyboard.isVisible = false;
-    cordova.fireWindowEvent('keyboardDidHide');
+Keyboard.fireOnHiding = function () {
+  // Automatic scroll to the top of the page
+  // to prevent quirks when using position:fixed elements
+  // inside WebKit browsers (iOS specifically).
+  // See CB-6444 for context.
+  if (Keyboard.automaticScrollToTopOnHiding) {
+    document.body.scrollLeft = 0;
+  }
 
-    if(Keyboard.onhide) {
-	Keyboard.onhide();
-    }
+  cordova.fireWindowEvent("keyboardWillHide");
+
+  if (Keyboard.onhiding) {
+    Keyboard.onhiding();
+  }
 };
 
-Keyboard.fireOnHiding = function() {
-    // Automatic scroll to the top of the page
-    // to prevent quirks when using position:fixed elements
-    // inside WebKit browsers (iOS specifically).
-    // See CB-6444 for context.
-    if (Keyboard.automaticScrollToTopOnHiding) {
-        document.body.scrollLeft = 0;
-    }
+Keyboard.fireOnShowing = function () {
+  cordova.fireWindowEvent("keyboardWillShow");
 
-    cordova.fireWindowEvent('keyboardWillHide');
-
-    if(Keyboard.onhiding) {
-	Keyboard.onhiding();
-    }
+  if (Keyboard.onshowing) {
+    Keyboard.onshowing();
+  }
 };
 
-Keyboard.fireOnShowing = function() {
-    cordova.fireWindowEvent('keyboardWillShow');
-
-    if(Keyboard.onshowing) {
-	Keyboard.onshowing();
-    }
+Keyboard.show = function () {
+  exec(null, null, "Keyboard", "show", []);
 };
 
-Keyboard.show = function() {
-    exec(null, null, "Keyboard", "show", []);
-};
-
-Keyboard.hide = function() {
-    exec(null, null, "Keyboard", "hide", []);
+Keyboard.hide = function () {
+  exec(null, null, "Keyboard", "hide", []);
 };
 
 Keyboard.isVisible = false;
 Keyboard.automaticScrollToTopOnHiding = false;
+
+channel.onCordovaReady.subscribe(function () {
+  exec(success, null, "Keyboard", "init", []);
+
+  function success(msg) {
+    var action = msg.charAt(0);
+    if (action === "S") {
+      var keyboardHeight = msg.substr(1);
+      Keyboard.isVisible = true;
+      cordova.fireWindowEvent("keyboardDidShow", {
+        keyboardHeight: +keyboardHeight,
+      });
+    } else if (action === "H") {
+      Keyboard.isVisible = false;
+      cordova.fireWindowEvent("keyboardDidHide");
+    }
+  }
+});
 
 module.exports = Keyboard;


### PR DESCRIPTION
Fork元のレポジトリーでは、Androidのキーボート表示隠すがありません。

以下のプルリクを参照（ほぼ同じ）して、ブランチを作成しました。
https://github.com/cjpearson/cordova-plugin-keyboard/pull/15 